### PR TITLE
Set native driver to false.

### DIFF
--- a/src/AnimatedProgressBar.js
+++ b/src/AnimatedProgressBar.js
@@ -61,6 +61,7 @@ class ProgressBar extends React.Component {
       easing: Easing[this.props.barEasing],
       toValue: toValue > 0 ? toValue : 0,
       duration: this.props.barAnimationDuration,
+      useNativeDriver: false
     }).start();
   }
 
@@ -68,6 +69,7 @@ class ProgressBar extends React.Component {
     Animated.timing(this.backgroundAnimation, {
       toValue: 1,
       duration: this.props.backgroundAnimationDuration,
+      useNativeDriver: false
     }).start();
   }
 
@@ -94,6 +96,7 @@ class ProgressBar extends React.Component {
           width: this.widthAnimation,
           backgroundColor: this.backgroundInterpolationValue || this.props.backgroundColor,
           borderRadius: this.props.borderRadius,
+          useNativeDriver: false
         }}
         />
       </View>


### PR DESCRIPTION
(WARN `useNativeDriver` was not specified. This is a required option and must be explicitly set to `true` or `false`) lead to random force close and apps reload in some cases.